### PR TITLE
feat: INT8 quantized inference with optimized GEMV/GEMM kernels

### DIFF
--- a/faster3a_2605/cuda/rwkv7_int8_ops.cpp
+++ b/faster3a_2605/cuda/rwkv7_int8_ops.cpp
@@ -1,0 +1,144 @@
+#include <torch/extension.h>
+
+// Forward declarations (from .cu)
+at::Tensor linear_int8_orig_rows_exact_f16_cuda(
+    at::Tensor x, at::Tensor w_orig, at::Tensor scale,
+    int64_t threads, int64_t out_tile, bool use4);
+at::Tensor linear_int8_f16_cuda(
+    at::Tensor x, at::Tensor w_int8, at::Tensor w_scale);
+at::Tensor dequant_int8_to_f16_cuda(
+    at::Tensor w_int8, at::Tensor scale, bool transpose);
+at::Tensor linear_int8_orig_rows_f16_cuda(
+    at::Tensor x, at::Tensor w_orig, at::Tensor scale,
+    int64_t row_tile, int64_t out_tile);
+
+void check_half_cuda_contig(const torch::Tensor& t, const char* name) {
+  TORCH_CHECK(t.device().type() == torch::kCUDA, name, " must be CUDA");
+  TORCH_CHECK(t.dtype() == torch::kHalf, name, " must be half");
+  TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+}
+
+void check_int8_cuda_contig(const torch::Tensor& t, const char* name) {
+  TORCH_CHECK(t.device().type() == torch::kCUDA, name, " must be CUDA");
+  TORCH_CHECK(t.dtype() == torch::kInt8, name, " must be int8");
+  TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+}
+
+// ═══════════════════════════════════════════════════════════════
+// linear_int8_orig_rows_exact_f16
+//   x      [M,K]    fp16  (M=1 或 M=2)
+//   w_orig [N,K]    int8  (orig 布局，不转置)
+//   scale  [N]      fp16
+//   threads, out_tile, use4 — 和原版 linear_orig_rows_exact_f16 相同
+// ═══════════════════════════════════════════════════════════════
+
+torch::Tensor linear_int8_orig_rows_exact_f16(
+    torch::Tensor x,
+    torch::Tensor w_orig,
+    torch::Tensor scale,
+    int64_t threads,
+    int64_t out_tile,
+    bool use4) {
+  check_half_cuda_contig(x, "x");
+  check_int8_cuda_contig(w_orig, "w_orig");
+  check_half_cuda_contig(scale, "scale");
+  TORCH_CHECK(x.dim() >= 2, "x must have at least 2 dims");
+  TORCH_CHECK(w_orig.dim() == 2, "w_orig must be 2D [N, K]");
+  TORCH_CHECK(scale.dim() == 1, "scale must be 1D [N]");
+  int64_t K = x.size(-1);
+  int64_t N = w_orig.size(0);
+  TORCH_CHECK(w_orig.size(1) == K, "w_orig K mismatch: ", w_orig.size(1), " vs ", K);
+  TORCH_CHECK(scale.size(0) == N, "scale N mismatch: ", scale.size(0), " vs ", N);
+  return linear_int8_orig_rows_exact_f16_cuda(x, w_orig, scale, threads, out_tile, use4);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// linear_int8_f16 — M>1 fallback（per-token 量化 + int8×int8）
+//   x      [M,K]    fp16
+//   w_int8 [K,N]    int8  (non-orig 布局，已转置)
+//   w_scale [N]     fp16
+// ═══════════════════════════════════════════════════════════════
+
+torch::Tensor linear_int8_f16(
+    torch::Tensor x,
+    torch::Tensor w_int8,
+    torch::Tensor w_scale) {
+  check_half_cuda_contig(x, "x");
+  check_int8_cuda_contig(w_int8, "w_int8");
+  check_half_cuda_contig(w_scale, "w_scale");
+  TORCH_CHECK(x.dim() >= 2, "x must have at least 2 dims, got ", x.dim());
+  TORCH_CHECK(w_int8.dim() == 2, "w_int8 must be 2D [K, N]");
+  TORCH_CHECK(w_scale.dim() == 1, "w_scale must be 1D [N]");
+  int64_t K = x.size(-1);
+  int64_t N = w_int8.size(1);
+  TORCH_CHECK(w_int8.size(0) == K, "w_int8 K mismatch: ", w_int8.size(0), " vs ", K);
+  TORCH_CHECK(w_scale.size(0) == N, "w_scale N mismatch");
+  return linear_int8_f16_cuda(x, w_int8, w_scale);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// dequant_int8_to_f16 — 批量反量化 int8→fp16（可选转置）
+//   w_int8  [N,K]   int8
+//   scale   [N]     fp16
+//   transpose=false → 输出 [N,K] fp16（orig 布局）
+//   transpose=true  → 输出 [K,N] fp16（non-orig 布局）
+// ═══════════════════════════════════════════════════════════════
+
+torch::Tensor dequant_int8_to_f16(
+    torch::Tensor w_int8,
+    torch::Tensor scale,
+    bool transpose) {
+  check_int8_cuda_contig(w_int8, "w_int8");
+  check_half_cuda_contig(scale, "scale");
+  TORCH_CHECK(w_int8.dim() == 2, "w_int8 must be 2D [N, K]");
+  TORCH_CHECK(scale.dim() == 1, "scale must be 1D [N]");
+  TORCH_CHECK(scale.size(0) == w_int8.size(0), "scale N mismatch");
+  return dequant_int8_to_f16_cuda(w_int8, scale, transpose);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// linear_int8_orig_rows_f16 — M≥3 GEMM with int8 weights
+//   x      [M,K]    fp16
+//   w_orig [N,K]    int8  (orig 布局，不转置)
+//   scale  [N]      fp16
+//   row_tile, out_tile — tiling 参数，和原版 linear_orig_rows_f16 一致
+// ═══════════════════════════════════════════════════════════════
+
+torch::Tensor linear_int8_orig_rows_f16(
+    torch::Tensor x,
+    torch::Tensor w_orig,
+    torch::Tensor scale,
+    int64_t row_tile,
+    int64_t out_tile) {
+  check_half_cuda_contig(x, "x");
+  check_int8_cuda_contig(w_orig, "w_orig");
+  check_half_cuda_contig(scale, "scale");
+  TORCH_CHECK(x.dim() >= 2, "x must have at least 2 dims");
+  TORCH_CHECK(w_orig.dim() == 2, "w_orig must be 2D [N, K]");
+  TORCH_CHECK(scale.dim() == 1, "scale must be 1D [N]");
+  int64_t K = x.size(-1);
+  int64_t N = w_orig.size(0);
+  int64_t M = x.numel() / K;
+  TORCH_CHECK(w_orig.size(1) == K, "w_orig K mismatch: ", w_orig.size(1), " vs ", K);
+  TORCH_CHECK(scale.size(0) == N, "scale N mismatch: ", scale.size(0), " vs ", N);
+  TORCH_CHECK(M >= 3, "linear_int8_orig_rows_f16 requires M>=3, got ", M);
+  return linear_int8_orig_rows_f16_cuda(x, w_orig, scale, row_tile, out_tile);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// TORCH_LIBRARY 注册
+// ═══════════════════════════════════════════════════════════════
+
+TORCH_LIBRARY(rwkv7_int8_ops, m) {
+  m.def("linear_int8_orig_rows_exact_f16(Tensor x, Tensor w_orig, Tensor scale, int threads, int out_tile, bool use4) -> Tensor");
+  m.def("linear_int8_f16(Tensor x, Tensor w_int8, Tensor w_scale) -> Tensor");
+  m.def("dequant_int8_to_f16(Tensor w_int8, Tensor scale, bool transpose) -> Tensor");
+  m.def("linear_int8_orig_rows_f16(Tensor x, Tensor w_orig, Tensor scale, int row_tile, int out_tile) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(rwkv7_int8_ops, CUDA, m) {
+  m.impl("linear_int8_orig_rows_exact_f16", &linear_int8_orig_rows_exact_f16);
+  m.impl("linear_int8_f16", &linear_int8_f16);
+  m.impl("dequant_int8_to_f16", &dequant_int8_to_f16);
+  m.impl("linear_int8_orig_rows_f16", &linear_int8_orig_rows_f16);
+}

--- a/faster3a_2605/cuda/rwkv7_int8_ops.cu
+++ b/faster3a_2605/cuda/rwkv7_int8_ops.cu
@@ -1,0 +1,691 @@
+// ═══════════════════════════════════════════════════════════════════════
+// rwkv7_int8_ops.cu — INT8 量化推理 CUDA kernel
+//
+// 在原版 v3a fp16 GEMV kernel 基础上，将权重从 fp16 改为 int8 + per-channel scale。
+// x 保持 fp16 不变，kernel 内读 int8 权重时即时乘 scale 还原为 float 再做 fmaf。
+// 权重读取量减半，GEMV 带宽瓶颈场景下提速明显。
+// kernel 结构（grid/block/reduce）与原版完全一致，仅权重读取方式不同。
+// ═══════════════════════════════════════════════════════════════════════
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <cuda_fp16.h>
+#include <algorithm>
+#include <climits>
+
+using dtype = __half;
+
+// warp 内 butterfly reduce 求和
+__device__ __forceinline__ float warp_sum(float x) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1)
+    x += __shfl_down_sync(0xffffffffu, x, offset);
+  return x;
+}
+
+// warp 内求最大值，用于 M>1 fallback kernel
+__device__ float warp_reduce_max(float val) {
+  for (int offset = 16; offset > 0; offset >>= 1)
+    val = fmaxf(val, __shfl_xor_sync(0xffffffff, val, offset));
+  return val;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Kernel A: M=1 GEMV，int8 权重 [N,K] + scale [N]
+//   Use4=false → 2-wide K 循环
+//   Use4=true  → 4-wide K 循环
+//
+// 输入：x [K] fp16, w_orig [N,K] int8, scale [N] fp16
+// 输出：y [N] fp16
+// ═══════════════════════════════════════════════════════════════════════
+
+template <int Threads, int OutTile, bool Use4>
+__global__ __launch_bounds__(Threads, 10) void linear_int8_orig_row1_exact_kernel(
+    int K,
+    int N,
+    const dtype* __restrict__ x,
+    const int8_t* __restrict__ w_orig,
+    const dtype* __restrict__ scale,
+    dtype* __restrict__ y) {
+
+  const int n0 = blockIdx.x * OutTile;
+
+  float acc[OutTile];
+  float s[OutTile];  // scale 预读到寄存器，避免 K 循环内重复读 global memory
+
+#pragma unroll
+  for (int j = 0; j < OutTile; ++j) {
+    acc[j] = 0.0f;
+    s[j] = __half2float(scale[n0 + j]);
+  }
+
+  if constexpr (Use4) {
+    // 4-wide: 每次迭代处理 4 个 K 元素
+    for (int k = threadIdx.x << 2; k < K; k += Threads << 2) {
+      const float2 x0 = __half22float2(*reinterpret_cast<const __half2*>(x + k));
+      const float2 x1 = __half22float2(*reinterpret_cast<const __half2*>(x + k + 2));
+#pragma unroll
+      for (int j = 0; j < OutTile; ++j) {
+        const int8_t* wj = w_orig + static_cast<int64_t>(n0 + j) * K + k;
+        acc[j] = fmaf(x0.x, (float)wj[0] * s[j], acc[j]);
+        acc[j] = fmaf(x0.y, (float)wj[1] * s[j], acc[j]);
+        acc[j] = fmaf(x1.x, (float)wj[2] * s[j], acc[j]);
+        acc[j] = fmaf(x1.y, (float)wj[3] * s[j], acc[j]);
+      }
+    }
+  } else {
+    // 2-wide: 每次迭代处理 2 个 K 元素
+    for (int k2 = threadIdx.x; k2 < (K >> 1); k2 += Threads) {
+      const int k = k2 << 1;
+      const float2 xv = __half22float2(*reinterpret_cast<const __half2*>(x + k));
+#pragma unroll
+      for (int j = 0; j < OutTile; ++j) {
+        const int8_t* wj = w_orig + static_cast<int64_t>(n0 + j) * K + k;
+        acc[j] = fmaf(xv.x, (float)wj[0] * s[j], acc[j]);
+        acc[j] = fmaf(xv.y, (float)wj[1] * s[j], acc[j]);
+      }
+    }
+  }
+
+  // warp 内 reduce → shared memory → thread 0 求和写出
+  __shared__ float partial[Threads / 32][OutTile];
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+#pragma unroll
+  for (int j = 0; j < OutTile; ++j) {
+    const float v = warp_sum(acc[j]);
+    if (lane == 0) {
+      partial[warp][j] = v;
+    }
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) {
+#pragma unroll
+    for (int j = 0; j < OutTile; ++j) {
+      float sum = 0.0f;
+#pragma unroll
+      for (int w = 0; w < Threads / 32; ++w) {
+        sum += partial[w][j];
+      }
+      y[n0 + j] = __float2half_rn(sum);
+    }
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Kernel B: M=2 GEMV，两行输入共享 int8 权重读取
+//
+// 输入：x [2,K] fp16, w_orig [N,K] int8, scale [N] fp16
+// 输出：y [2,N] fp16
+// ═══════════════════════════════════════════════════════════════════════
+
+template <int Threads, int OutTile, bool Use4>
+__global__ __launch_bounds__(Threads, 10) void linear_int8_orig_row2_exact_kernel(
+    int K,
+    int N,
+    const dtype* __restrict__ x,
+    const int8_t* __restrict__ w_orig,
+    const dtype* __restrict__ scale,
+    dtype* __restrict__ y) {
+
+  const int n0 = blockIdx.x * OutTile;
+  float acc0[OutTile];
+  float acc1[OutTile];
+  float s[OutTile];
+
+#pragma unroll
+  for (int j = 0; j < OutTile; ++j) {
+    acc0[j] = 0.0f;
+    acc1[j] = 0.0f;
+    s[j] = __half2float(scale[n0 + j]);
+  }
+
+  if constexpr (Use4) {
+    for (int k = threadIdx.x << 2; k < K; k += Threads << 2) {
+      const float2 x00 = __half22float2(*reinterpret_cast<const __half2*>(x + k));
+      const float2 x01 = __half22float2(*reinterpret_cast<const __half2*>(x + k + 2));
+      const float2 x10 = __half22float2(*reinterpret_cast<const __half2*>(x + K + k));
+      const float2 x11 = __half22float2(*reinterpret_cast<const __half2*>(x + K + k + 2));
+#pragma unroll
+      for (int j = 0; j < OutTile; ++j) {
+        const int8_t* wj = w_orig + static_cast<int64_t>(n0 + j) * K + k;
+        acc0[j] = fmaf(x00.x, (float)wj[0] * s[j], acc0[j]);
+        acc0[j] = fmaf(x00.y, (float)wj[1] * s[j], acc0[j]);
+        acc0[j] = fmaf(x01.x, (float)wj[2] * s[j], acc0[j]);
+        acc0[j] = fmaf(x01.y, (float)wj[3] * s[j], acc0[j]);
+        acc1[j] = fmaf(x10.x, (float)wj[0] * s[j], acc1[j]);
+        acc1[j] = fmaf(x10.y, (float)wj[1] * s[j], acc1[j]);
+        acc1[j] = fmaf(x11.x, (float)wj[2] * s[j], acc1[j]);
+        acc1[j] = fmaf(x11.y, (float)wj[3] * s[j], acc1[j]);
+      }
+    }
+  } else {
+    for (int k2 = threadIdx.x; k2 < (K >> 1); k2 += Threads) {
+      const int k = k2 << 1;
+      const float2 x0 = __half22float2(*reinterpret_cast<const __half2*>(x + k));
+      const float2 x1 = __half22float2(*reinterpret_cast<const __half2*>(x + K + k));
+#pragma unroll
+      for (int j = 0; j < OutTile; ++j) {
+        const int8_t* wj = w_orig + static_cast<int64_t>(n0 + j) * K + k;
+        acc0[j] = fmaf(x0.x, (float)wj[0] * s[j], acc0[j]);
+        acc0[j] = fmaf(x0.y, (float)wj[1] * s[j], acc0[j]);
+        acc1[j] = fmaf(x1.x, (float)wj[0] * s[j], acc1[j]);
+        acc1[j] = fmaf(x1.y, (float)wj[1] * s[j], acc1[j]);
+      }
+    }
+  }
+
+  __shared__ float partial[Threads / 32][2][OutTile];
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+#pragma unroll
+  for (int j = 0; j < OutTile; ++j) {
+    const float v0 = warp_sum(acc0[j]);
+    const float v1 = warp_sum(acc1[j]);
+    if (lane == 0) {
+      partial[warp][0][j] = v0;
+      partial[warp][1][j] = v1;
+    }
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) {
+#pragma unroll
+    for (int j = 0; j < OutTile; ++j) {
+      float sum0 = 0.0f;
+      float sum1 = 0.0f;
+#pragma unroll
+      for (int w = 0; w < Threads / 32; ++w) {
+        sum0 += partial[w][0][j];
+        sum1 += partial[w][1][j];
+      }
+      const int n = n0 + j;
+      y[n] = __float2half_rn(sum0);
+      y[N + n] = __float2half_rn(sum1);
+    }
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Kernel C: M>1 fallback，per-token 量化 x 后做 int8×int8 matmul
+// 仅用于 M>2 的 prefill 场景，实际推理极少触发
+// ═══════════════════════════════════════════════════════════════════════
+
+template <int Threads>
+__global__ void linear_int8_f16_kernel(
+    const dtype* __restrict__ x,
+    const int8_t* __restrict__ w_int8,
+    const dtype* __restrict__ w_scale,
+    dtype* __restrict__ y,
+    int M, int K, int N) {
+
+  __shared__ int8_t xs[16384];
+  __shared__ float s_max_abs;
+
+  int row = blockIdx.x;
+  if (row >= M) return;
+
+  // per-token 量化 x
+  float local_max = 0.0f;
+  for (int k = threadIdx.x; k < K; k += Threads) {
+    float v = __half2float(x[row * (int64_t)K + k]);
+    local_max = fmaxf(local_max, fabsf(v));
+  }
+  local_max = warp_reduce_max(local_max);
+  if (threadIdx.x == 0) s_max_abs = fmaxf(local_max, 1e-10f);
+  __syncthreads();
+
+  float scale_x = s_max_abs / 127.0f;
+
+  for (int k = threadIdx.x; k < K; k += Threads) {
+    xs[k] = (int8_t)max(-128, min(127, __float2int_rn(__half2float(x[row * (int64_t)K + k]) / scale_x)));
+  }
+  __syncthreads();
+
+  for (int col_base = threadIdx.x; col_base < N; col_base += Threads) {
+    int col = col_base;
+    int32_t acc = 0;
+    for (int k = 0; k < K; k += 1) {
+      acc += (int32_t)xs[k] * (int32_t)w_int8[k * (int64_t)N + col];
+    }
+    y[row * (int64_t)N + col] = __float2half((float)acc * scale_x * __half2float(w_scale[col]));
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Kernel E: M≥3 GEMM，int8 权重 [N,K] + scale [N]
+//   1:1 复制原版 linear_orig_rows_f16_kernel，权重改为 int8 + scale
+//   用于 prefill (M>2) 场景，替代 dequant + cuBLAS 路径，消除临时 fp16 张量
+//
+// 输入：x [M,K] fp16, w_orig [N,K] int8, scale [N] fp16
+// 输出：y [M,N] fp16
+// ═══════════════════════════════════════════════════════════════════════
+
+template <int Threads, int RowTile, int OutTile, bool Use4>
+__global__ __launch_bounds__(Threads, 1) void linear_int8_orig_rows_kernel(
+    int M,
+    int K,
+    int N,
+    const dtype* __restrict__ x,
+    const int8_t* __restrict__ w_orig,
+    const dtype* __restrict__ scale,
+    dtype* __restrict__ y) {
+
+  const int n0 = blockIdx.x * OutTile;
+  const int m0 = blockIdx.y * RowTile;
+
+  float acc[RowTile][OutTile];
+  float s[OutTile];
+
+#pragma unroll
+  for (int j = 0; j < OutTile; ++j) {
+    s[j] = __half2float(scale[n0 + j]);
+  }
+#pragma unroll
+  for (int r = 0; r < RowTile; ++r) {
+#pragma unroll
+    for (int j = 0; j < OutTile; ++j) {
+      acc[r][j] = 0.0f;
+    }
+  }
+
+  if constexpr (Use4) {
+    // 4-wide: 每次迭代处理 4 个 K 元素，减少 50% 循环次数
+    const int K4 = K >> 2;
+    for (int k4 = threadIdx.x; k4 < K4; k4 += Threads) {
+      const int k = k4 << 2;
+      float wv[OutTile][4];
+#pragma unroll
+      for (int j = 0; j < OutTile; ++j) {
+        const int n = n0 + j;
+        if (n < N) {
+          const int8_t* wj = w_orig + static_cast<int64_t>(n) * K + k;
+          wv[j][0] = (float)wj[0] * s[j];
+          wv[j][1] = (float)wj[1] * s[j];
+          wv[j][2] = (float)wj[2] * s[j];
+          wv[j][3] = (float)wj[3] * s[j];
+        } else {
+          wv[j][0] = wv[j][1] = wv[j][2] = wv[j][3] = 0.0f;
+        }
+      }
+#pragma unroll
+      for (int r = 0; r < RowTile; ++r) {
+        const int m = m0 + r;
+        if (m < M) {
+          const float2 x0 = __half22float2(*reinterpret_cast<const __half2*>(x + static_cast<int64_t>(m) * K + k));
+          const float2 x1 = __half22float2(*reinterpret_cast<const __half2*>(x + static_cast<int64_t>(m) * K + k + 2));
+#pragma unroll
+          for (int j = 0; j < OutTile; ++j) {
+            acc[r][j] = fmaf(x0.x, wv[j][0], acc[r][j]);
+            acc[r][j] = fmaf(x0.y, wv[j][1], acc[r][j]);
+            acc[r][j] = fmaf(x1.x, wv[j][2], acc[r][j]);
+            acc[r][j] = fmaf(x1.y, wv[j][3], acc[r][j]);
+          }
+        }
+      }
+    }
+    // K%4 尾部（最多 3 个元素）
+    const int k_tail_start = K4 << 2;
+    if (k_tail_start < K && threadIdx.x == 0) {
+#pragma unroll
+      for (int j = 0; j < OutTile; ++j) {
+        const int n = n0 + j;
+        if (n < N) {
+          const int8_t* wj = w_orig + static_cast<int64_t>(n) * K + k_tail_start;
+#pragma unroll
+          for (int r = 0; r < RowTile; ++r) {
+            const int m = m0 + r;
+            if (m < M) {
+              const dtype* xr = x + static_cast<int64_t>(m) * K + k_tail_start;
+#pragma unroll
+              for (int t = 0; t < 4 && k_tail_start + t < K; ++t) {
+                acc[r][j] = fmaf(__half2float(xr[t]), (float)wj[t] * s[j], acc[r][j]);
+              }
+            }
+          }
+        }
+      }
+    }
+  } else {
+    // 2-wide: 每次迭代处理 2 个 K 元素
+    const int K2 = K >> 1;
+    for (int k2 = threadIdx.x; k2 < K2; k2 += Threads) {
+      const int k = k2 << 1;
+      float wv[OutTile][2];
+#pragma unroll
+      for (int j = 0; j < OutTile; ++j) {
+        const int n = n0 + j;
+        if (n < N) {
+          const int8_t* wj = w_orig + static_cast<int64_t>(n) * K + k;
+          wv[j][0] = (float)wj[0] * s[j];
+          wv[j][1] = (float)wj[1] * s[j];
+        } else {
+          wv[j][0] = 0.0f;
+          wv[j][1] = 0.0f;
+        }
+      }
+#pragma unroll
+      for (int r = 0; r < RowTile; ++r) {
+        const int m = m0 + r;
+        if (m < M) {
+          const float2 xv = __half22float2(*reinterpret_cast<const __half2*>(x + static_cast<int64_t>(m) * K + k));
+#pragma unroll
+          for (int j = 0; j < OutTile; ++j) {
+            acc[r][j] = fmaf(xv.x, wv[j][0], acc[r][j]);
+            acc[r][j] = fmaf(xv.y, wv[j][1], acc[r][j]);
+          }
+        }
+      }
+    }
+    // K 奇数尾部
+    if ((K & 1) && threadIdx.x == 0) {
+#pragma unroll
+      for (int j = 0; j < OutTile; ++j) {
+        const int n = n0 + j;
+        if (n < N) {
+          const float wv = (float)w_orig[static_cast<int64_t>(n) * K + K - 1] * s[j];
+#pragma unroll
+          for (int r = 0; r < RowTile; ++r) {
+            const int m = m0 + r;
+            if (m < M) {
+              const float xv = __half2float(*reinterpret_cast<const __half*>(x + static_cast<int64_t>(m) * K + K - 1));
+              acc[r][j] = fmaf(xv, wv, acc[r][j]);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // warp reduce → shared memory → thread 0 写出
+  __shared__ float partial[Threads / 32][RowTile][OutTile];
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+#pragma unroll
+  for (int r = 0; r < RowTile; ++r) {
+#pragma unroll
+    for (int j = 0; j < OutTile; ++j) {
+      const float v = warp_sum(acc[r][j]);
+      if (lane == 0) {
+        partial[warp][r][j] = v;
+      }
+    }
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) {
+#pragma unroll
+    for (int r = 0; r < RowTile; ++r) {
+      const int m = m0 + r;
+      if (m < M) {
+#pragma unroll
+        for (int j = 0; j < OutTile; ++j) {
+          const int n = n0 + j;
+          if (n < N) {
+            float sum = 0.0f;
+#pragma unroll
+            for (int w = 0; w < Threads / 32; ++w) {
+              sum += partial[w][r][j];
+            }
+            *reinterpret_cast<__half*>(y + static_cast<int64_t>(m) * N + n) = __float2half_rn(sum);
+          }
+        }
+      }
+    }
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Host wrappers
+// ═══════════════════════════════════════════════════════════════════════
+
+template <int Threads, int OutTile, bool Use4>
+at::Tensor linear_int8_orig_row1_exact_f16_cuda_impl(at::Tensor x, at::Tensor w_orig, at::Tensor scale) {
+  const int64_t k64 = x.size(-1);
+  const int64_t n64 = w_orig.size(0);
+  TORCH_CHECK(k64 <= INT_MAX && n64 <= INT_MAX, "linear_int8_orig_row1_exact_f16 K/N too large");
+  TORCH_CHECK((n64 % OutTile) == 0, "linear_int8_orig_row1_exact_f16 requires N divisible by out_tile");
+  TORCH_CHECK((k64 % (Use4 ? 4 : 2)) == 0, "linear_int8_orig_row1_exact_f16 unsupported K alignment");
+  const int K = static_cast<int>(k64);
+  const int N = static_cast<int>(n64);
+  const int64_t m64 = x.numel() / k64;
+  TORCH_CHECK(m64 == 1, "linear_int8_orig_row1_exact_f16 requires one row");
+
+  std::vector<int64_t> out_sizes(x.sizes().begin(), x.sizes().end());
+  out_sizes.back() = n64;
+  auto y = at::empty(out_sizes, x.options());
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  linear_int8_orig_row1_exact_kernel<Threads, OutTile, Use4>
+      <<<N / OutTile, Threads, 0, stream>>>(
+          K, N,
+          reinterpret_cast<const dtype*>(x.data_ptr<at::Half>()),
+          w_orig.data_ptr<int8_t>(),
+          reinterpret_cast<const dtype*>(scale.data_ptr<at::Half>()),
+          reinterpret_cast<dtype*>(y.data_ptr<at::Half>()));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return y;
+}
+
+template <int Threads, int OutTile, bool Use4>
+at::Tensor linear_int8_orig_row2_exact_f16_cuda_impl(at::Tensor x, at::Tensor w_orig, at::Tensor scale) {
+  const int64_t k64 = x.size(-1);
+  const int64_t n64 = w_orig.size(0);
+  TORCH_CHECK(k64 <= INT_MAX && n64 <= INT_MAX, "linear_int8_orig_row2_exact_f16 K/N too large");
+  TORCH_CHECK((n64 % OutTile) == 0, "linear_int8_orig_row2_exact_f16 requires N divisible by out_tile");
+  TORCH_CHECK((k64 % (Use4 ? 4 : 2)) == 0, "linear_int8_orig_row2_exact_f16 unsupported K alignment");
+  const int K = static_cast<int>(k64);
+  const int N = static_cast<int>(n64);
+  const int64_t m64 = x.numel() / k64;
+  TORCH_CHECK(m64 == 2, "linear_int8_orig_row2_exact_f16 requires two rows");
+  std::vector<int64_t> out_sizes(x.sizes().begin(), x.sizes().end());
+  out_sizes.back() = n64;
+  auto y = at::empty(out_sizes, x.options());
+  auto stream = at::cuda::getCurrentCUDAStream();
+  linear_int8_orig_row2_exact_kernel<Threads, OutTile, Use4>
+      <<<N / OutTile, Threads, 0, stream>>>(
+          K, N,
+          reinterpret_cast<const dtype*>(x.data_ptr<at::Half>()),
+          w_orig.data_ptr<int8_t>(),
+          reinterpret_cast<const dtype*>(scale.data_ptr<at::Half>()),
+          reinterpret_cast<dtype*>(y.data_ptr<at::Half>()));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return y;
+}
+
+// 顶层 dispatch：参数选择与原版一致
+at::Tensor linear_int8_orig_rows_exact_f16_cuda(
+    at::Tensor x, at::Tensor w_orig, at::Tensor scale,
+    int64_t threads, int64_t out_tile, bool use4) {
+  const int64_t rows = x.numel() / x.size(-1);
+  if (rows == 1) {
+    if (!use4 && threads == 128 && out_tile == 2) return linear_int8_orig_row1_exact_f16_cuda_impl<128, 2, false>(x, w_orig, scale);
+    if (use4 && threads == 128 && out_tile == 2) return linear_int8_orig_row1_exact_f16_cuda_impl<128, 2, true>(x, w_orig, scale);
+  }
+  if (rows == 2) {
+    if (use4 && threads == 64 && out_tile == 2) return linear_int8_orig_row2_exact_f16_cuda_impl<64, 2, true>(x, w_orig, scale);
+    if (use4 && threads == 256 && out_tile == 1) return linear_int8_orig_row2_exact_f16_cuda_impl<256, 1, true>(x, w_orig, scale);
+    if (!use4 && threads == 128 && out_tile == 2) return linear_int8_orig_row2_exact_f16_cuda_impl<128, 2, false>(x, w_orig, scale);
+  }
+  TORCH_CHECK(false, "unsupported linear_int8_orig_rows_exact_f16 rows/threads/out_tile/use4");
+}
+
+// M>1 fallback wrapper
+at::Tensor linear_int8_f16_cuda(
+    at::Tensor x,
+    at::Tensor w_int8,
+    at::Tensor w_scale) {
+
+  int64_t K = x.size(-1);
+  int64_t N = w_int8.size(1);
+  int64_t M = x.numel() / K;
+
+  auto y = at::empty({M, N}, x.options());
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  constexpr int Threads = 256;
+  linear_int8_f16_kernel<Threads>
+      <<<(int)M, Threads, 0, stream>>>(
+          reinterpret_cast<const dtype*>(x.data_ptr<at::Half>()),
+          w_int8.data_ptr<int8_t>(),
+          reinterpret_cast<const dtype*>(w_scale.data_ptr<at::Half>()),
+          reinterpret_cast<dtype*>(y.data_ptr<at::Half>()),
+          (int)M, (int)K, (int)N);
+
+  return y;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Kernel D: 批量 dequant int8[N,K] → fp16[N,K]（可选转置为 [K,N]）
+// 用于 prefill (M>2) 场景，替代 Python 多步 dequant 链
+//
+// 输入：w_int8 [N,K] int8, scale [N] fp16
+// 输出：w_fp16 [N,K] 或 [K,N] fp16
+// transpose=false → 输出 [N,K]（orig 布局）
+// transpose=true  → 输出 [K,N]（non-orig 布局，用于 linear/splitk）
+// ═══════════════════════════════════════════════════════════════════════
+
+template <int Threads, bool Transpose>
+__global__ void dequant_int8_to_f16_kernel(
+    const int8_t* __restrict__ w_int8,
+    const dtype* __restrict__ scale,
+    dtype* __restrict__ w_fp16,
+    int N, int K) {
+
+  // 每个 block 处理一行（N 维度的一行）
+  int n = blockIdx.x;
+  if (n >= N) return;
+
+  float s = __half2float(scale[n]);
+  const int8_t* wj = w_int8 + static_cast<int64_t>(n) * K;
+
+  if constexpr (!Transpose) {
+    // 非转置：输出 [N,K]，连续写入，可用 half2 向量化
+    dtype* out = w_fp16 + static_cast<int64_t>(n) * K;
+    // 一次处理 8 个元素（2 个 int4 读 = 16 个 int8，但用 8 更对齐 K%8==0 常见情况）
+    int k = threadIdx.x * 8;
+    for (; k + 7 < K; k += Threads * 8) {
+      // 读 8 个 int8（2 次 int32 加载）
+      const int32_t* w32 = reinterpret_cast<const int32_t*>(wj + k);
+      int32_t w0 = w32[0];  // 4 个 int8
+      int32_t w1 = w32[1];  // 4 个 int8
+      // 转换为 float 再乘 scale
+      float f0 = static_cast<float>(static_cast<int8_t>(w0 & 0xFF)) * s;
+      float f1 = static_cast<float>(static_cast<int8_t>((w0 >> 8) & 0xFF)) * s;
+      float f2 = static_cast<float>(static_cast<int8_t>((w0 >> 16) & 0xFF)) * s;
+      float f3 = static_cast<float>(static_cast<int8_t>((w0 >> 24) & 0xFF)) * s;
+      float f4 = static_cast<float>(static_cast<int8_t>(w1 & 0xFF)) * s;
+      float f5 = static_cast<float>(static_cast<int8_t>((w1 >> 8) & 0xFF)) * s;
+      float f6 = static_cast<float>(static_cast<int8_t>((w1 >> 16) & 0xFF)) * s;
+      float f7 = static_cast<float>(static_cast<int8_t>((w1 >> 24) & 0xFF)) * s;
+      // 用 __floats2half2_rn 批量写 2 个 fp16
+      *reinterpret_cast<__half2*>(out + k)     = __floats2half2_rn(f0, f1);
+      *reinterpret_cast<__half2*>(out + k + 2) = __floats2half2_rn(f2, f3);
+      *reinterpret_cast<__half2*>(out + k + 4) = __floats2half2_rn(f4, f5);
+      *reinterpret_cast<__half2*>(out + k + 6) = __floats2half2_rn(f6, f7);
+    }
+    // 尾部
+    for (; k < K; k += Threads) {
+      out[k] = __float2half_rn(static_cast<float>(wj[k]) * s);
+    }
+  } else {
+    // 转置：输出 [K,N]，非连续写入，无法向量化
+    for (int k = threadIdx.x; k < K; k += Threads) {
+      float val = static_cast<float>(wj[k]) * s;
+      w_fp16[static_cast<int64_t>(k) * N + n] = __float2half_rn(val);
+    }
+  }
+}
+
+// Host wrapper
+at::Tensor dequant_int8_to_f16_cuda(
+    at::Tensor w_int8, at::Tensor scale, bool transpose) {
+
+  int64_t N = w_int8.size(0);
+  int64_t K = w_int8.size(1);
+
+  std::vector<int64_t> out_sizes;
+  if (transpose) {
+    out_sizes = {K, N};  // [K, N]
+  } else {
+    out_sizes = {N, K};  // [N, K]
+  }
+  auto w_fp16 = at::empty(out_sizes, scale.options());
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  constexpr int Threads = 256;
+  if (transpose) {
+    dequant_int8_to_f16_kernel<Threads, true>
+        <<<(int)N, Threads, 0, stream>>>(
+            w_int8.data_ptr<int8_t>(),
+            reinterpret_cast<const dtype*>(scale.data_ptr<at::Half>()),
+            reinterpret_cast<dtype*>(w_fp16.data_ptr<at::Half>()),
+            (int)N, (int)K);
+  } else {
+    dequant_int8_to_f16_kernel<Threads, false>
+        <<<(int)N, Threads, 0, stream>>>(
+            w_int8.data_ptr<int8_t>(),
+            reinterpret_cast<const dtype*>(scale.data_ptr<at::Half>()),
+            reinterpret_cast<dtype*>(w_fp16.data_ptr<at::Half>()),
+            (int)N, (int)K);
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return w_fp16;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// linear_int8_orig_rows_f16 — M≥3 GEMM with int8 weights
+//   x      [M,K]    fp16
+//   w_orig [N,K]    int8  (orig 布局，不转置)
+//   scale  [N]      fp16
+//   row_tile, out_tile — 和原版 linear_orig_rows_f16 相同的 tiling 参数
+// ═══════════════════════════════════════════════════════════════════════
+
+template <int Threads, int RowTile, int OutTile, bool Use4>
+at::Tensor linear_int8_orig_rows_f16_cuda_impl(at::Tensor x, at::Tensor w_orig, at::Tensor scale) {
+  const int64_t k64 = x.size(-1);
+  const int64_t n64 = w_orig.size(0);
+  const int64_t m64 = x.numel() / k64;
+  TORCH_CHECK(k64 <= INT_MAX && n64 <= INT_MAX && m64 <= INT_MAX, "linear_int8_orig_rows_f16 M/K/N too large");
+  const int M = static_cast<int>(m64);
+  const int K = static_cast<int>(k64);
+  const int N = static_cast<int>(n64);
+
+  std::vector<int64_t> out_sizes(x.sizes().begin(), x.sizes().end());
+  out_sizes.back() = n64;
+  auto y = at::empty(out_sizes, x.options());
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  dim3 grid((N + OutTile - 1) / OutTile, (M + RowTile - 1) / RowTile, 1);
+  linear_int8_orig_rows_kernel<Threads, RowTile, OutTile, Use4>
+      <<<grid, Threads, 0, stream>>>(
+          M, K, N,
+          reinterpret_cast<const dtype*>(x.data_ptr<at::Half>()),
+          w_orig.data_ptr<int8_t>(),
+          reinterpret_cast<const dtype*>(scale.data_ptr<at::Half>()),
+          reinterpret_cast<dtype*>(y.data_ptr<at::Half>()));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return y;
+}
+
+at::Tensor linear_int8_orig_rows_f16_cuda(
+    at::Tensor x, at::Tensor w_orig, at::Tensor scale,
+    int64_t row_tile, int64_t out_tile) {
+  // K%4==0 时用 4-wide K 循环（减少 50% 循环次数），否则用 2-wide
+  const bool use4 = (x.size(-1) % 4) == 0;
+  if (use4) {
+    if (row_tile == 4 && out_tile == 4) return linear_int8_orig_rows_f16_cuda_impl<128, 4, 4, true>(x, w_orig, scale);
+    if (row_tile == 4 && out_tile == 2) return linear_int8_orig_rows_f16_cuda_impl<128, 4, 2, true>(x, w_orig, scale);
+    if (row_tile == 8 && out_tile == 4) return linear_int8_orig_rows_f16_cuda_impl<128, 8, 4, true>(x, w_orig, scale);
+    if (row_tile == 8 && out_tile == 2) return linear_int8_orig_rows_f16_cuda_impl<128, 8, 2, true>(x, w_orig, scale);
+    if (row_tile == 16 && out_tile == 2) return linear_int8_orig_rows_f16_cuda_impl<128, 16, 2, true>(x, w_orig, scale);
+    if (row_tile == 16 && out_tile == 4) return linear_int8_orig_rows_f16_cuda_impl<128, 16, 4, true>(x, w_orig, scale);
+  } else {
+    if (row_tile == 4 && out_tile == 4) return linear_int8_orig_rows_f16_cuda_impl<128, 4, 4, false>(x, w_orig, scale);
+    if (row_tile == 4 && out_tile == 2) return linear_int8_orig_rows_f16_cuda_impl<128, 4, 2, false>(x, w_orig, scale);
+    if (row_tile == 8 && out_tile == 4) return linear_int8_orig_rows_f16_cuda_impl<128, 8, 4, false>(x, w_orig, scale);
+    if (row_tile == 8 && out_tile == 2) return linear_int8_orig_rows_f16_cuda_impl<128, 8, 2, false>(x, w_orig, scale);
+    if (row_tile == 16 && out_tile == 2) return linear_int8_orig_rows_f16_cuda_impl<128, 16, 2, false>(x, w_orig, scale);
+    if (row_tile == 16 && out_tile == 4) return linear_int8_orig_rows_f16_cuda_impl<128, 16, 4, false>(x, w_orig, scale);
+  }
+  TORCH_CHECK(false, "unsupported linear_int8_orig_rows_f16 row_tile/out_tile: ", row_tile, "/", out_tile);
+}

--- a/faster3a_2605/quantize_int8.py
+++ b/faster3a_2605/quantize_int8.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+RWKV-7 v3a 离线 INT8 量化工具
+
+将 FP16 模型量化为 INT8，输出新的 .pth 文件。
+推理引擎加载量化后的模型时，根据权重 dtype 自动选择 INT8 或 FP16 kernel。
+
+量化策略：
+  - per-channel symmetric INT8（scale = max_abs(row) / 127）
+  - 仅量化 orig 组大矩阵（att.r/k/v/o, ffn.key, head）
+  - ffn.value.weight 不量化（sparse cmix kernel 硬编码 fp16）
+  - 低秩权重不量化（收益小）
+  - Embedding / LN / r_k 不量化
+
+内存优化：
+  - 用 mmap 加载原始模型（不占内存）
+  - 创建全新 target 字典，逐个 .cpu() 复制张量（解除 mmap 映射）
+  - torch.save 只写新数据，不复制原始文件
+
+用法：
+  python3 quantize_int8.py --model model.pth --out model-int8.pth
+  python3 quantize_int8.py --model model.pth --out model-int8.pth --verify
+"""
+
+import argparse
+import os
+import sys
+import time
+
+import torch
+
+# 量化的权重后缀（全部是 orig 组）
+INT8_KEYS = (
+    ".att.receptance.weight",
+    ".att.key.weight",
+    ".att.value.weight",
+    ".att.output.weight",
+    ".ffn.key.weight",
+    "head.weight",
+)
+
+
+def quantize_weight_int8(w: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """per-channel symmetric INT8 量化。
+
+    Args:
+        w: [N, K] fp16/fp32 权重
+    Returns:
+        w_int8: [N, K] int8
+        scale:  [N] fp16
+    """
+    wf = w.float()  # [N, K]
+    max_abs = wf.abs().max(dim=1, keepdim=True).values  # [N, 1]
+    max_abs = torch.clamp(max_abs, min=1e-10)
+    scale = (max_abs / 127.0).squeeze(1).to(torch.float16)  # [N]
+    w_int8 = (wf / max_abs * 127.0).round().clamp(-128, 127).to(torch.int8)
+    return w_int8.contiguous(), scale.contiguous()
+
+
+def should_quantize(key: str) -> bool:
+    """判断该权重是否需要量化。"""
+    return any(s in key for s in INT8_KEYS)
+
+
+def cosine_similarity_fp64(a: torch.Tensor, b: torch.Tensor) -> float:
+    """用 float64 计算 cosine similarity，避免大向量的 float32 累积误差。"""
+    a64 = a.double()
+    b64 = b.double()
+    dot = torch.dot(a64, b64)
+    norm = a64.norm() * b64.norm()
+    return (dot / norm.clamp(min=1e-12)).item()
+
+
+def quantize_model(input_path: str, output_path: str, verify: bool = False) -> None:
+    """量化模型并保存。"""
+    t0 = time.perf_counter()
+    print(f"[quantize] loading {input_path}")
+    # mmap 加载：不占内存，张量按需从磁盘读取
+    src = torch.load(input_path, map_location="cpu", mmap=True)
+    print(f"[quantize] loaded {len(src)} tensors in {time.perf_counter() - t0:.1f}s")
+
+    quantized_count = 0
+    total_params = 0
+    quantized_params = 0
+
+    # 创建全新 target 字典：逐个 .cpu() 复制张量，解除 mmap 映射
+    # 这样 torch.save 只写新数据，不会把原始 mmap 文件复制进去
+    target: dict[str, torch.Tensor] = {}
+
+    t1 = time.perf_counter()
+    for key in list(src.keys()):
+        value = src[key].squeeze()
+        total_params += value.numel()
+
+        if should_quantize(key) and value.dim() == 2:
+            w_int8, scale = quantize_weight_int8(value)
+            target[key] = w_int8          # int8，已 .contiguous()，是普通张量
+            target[key + "_scale"] = scale  # fp16 [N]
+            quantized_count += 1
+            quantized_params += value.numel()
+        else:
+            # 未量化的权重：.clone() 复制解除 mmap 映射
+            # 注意：.cpu() 对已在 CPU 上的张量不复制，必须用 .clone()
+            target[key] = value.clone()
+
+    print(f"[quantize] quantized {quantized_count} weights "
+          f"({quantized_params / 1e6:.1f}M / {total_params / 1e6:.1f}M params) "
+          f"in {time.perf_counter() - t1:.1f}s")
+
+    # 验证：反量化后和原始权重的 CosSim（float64 避免精度误差）
+    if verify:
+        print("[quantize] verifying...")
+        z_ref = torch.load(input_path, map_location="cpu", mmap=True)
+        max_diff = 0.0
+        for key in list(target.keys()):
+            if key.endswith("_scale"):
+                continue
+            if target[key].dtype != torch.int8:
+                continue
+            ref = z_ref[key].squeeze().float()
+            w_int8 = target[key]
+            scale = target[key + "_scale"]
+            deq = w_int8.float() * scale.unsqueeze(1).float()
+            cos = cosine_similarity_fp64(ref.flatten(), deq.flatten())
+            max_diff = max(max_diff, 1.0 - cos)
+            print(f"  {key}: CosSim={cos:.6f}")
+        print(f"[quantize] max error (1-cossim): {max_diff:.6f}")
+
+    # 保存
+    t2 = time.perf_counter()
+    print(f"[quantize] saving to {output_path}")
+    torch.save(target, output_path)
+    file_size = os.path.getsize(output_path) / 1e9
+    print(f"[quantize] saved in {time.perf_counter() - t2:.1f}s, file size: {file_size:.2f} GB")
+    print(f"[quantize] done in {time.perf_counter() - t0:.1f}s total")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="RWKV-7 v3a 离线 INT8 量化工具")
+    parser.add_argument("--model", required=True, help="输入 FP16 模型路径")
+    parser.add_argument("--out", required=True, help="输出 INT8 模型路径")
+    parser.add_argument("--verify", action="store_true", help="量化后验证 CosSim")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.model):
+        print(f"[error] model not found: {args.model}")
+        sys.exit(1)
+
+    quantize_model(args.model, args.out, args.verify)
+
+
+if __name__ == "__main__":
+    main()

--- a/faster3a_2605/rwkv7_fast_v3a.py
+++ b/faster3a_2605/rwkv7_fast_v3a.py
@@ -216,16 +216,23 @@ def is_orig_linear_weight(key: str) -> bool:
 
 def load_extensions(wkv_mode: str = "fp16") -> None:
     t0 = time.perf_counter()
-    log(f"loading CUDA extensions v3a_ops + fast_ops + wkv={wkv_mode}")
+    log(f"loading CUDA extensions v3a_ops + fast_ops + int8_ops + wkv={wkv_mode}")
     cuda_flags = ["-O3", "--use_fast_math", "--extra-device-vectorization"] + ([] if os.name == "nt" else ["-Xptxas", "-O3"])
-    load(name="rwkv7_v3a_ops", sources=[str(CUDA_DIR / "rwkv7_v3a_ops.cpp"), str(CUDA_DIR / "rwkv7_v3a_ops.cu")], is_python_module=False, verbose=False, extra_cflags=["-O3"], extra_cuda_cflags=cuda_flags)
-    load(name="rwkv7_fast_ops_fp16", sources=[str(CUDA_DIR / "rwkv7_fast_ops_fp16.cpp"), str(CUDA_DIR / "rwkv7_fast_ops_fp16.cu")], is_python_module=False, verbose=False, extra_cflags=["-O3"], extra_cuda_cflags=cuda_flags)
+    exts = [
+        ("rwkv7_v3a_ops", [str(CUDA_DIR / "rwkv7_v3a_ops.cpp"), str(CUDA_DIR / "rwkv7_v3a_ops.cu")], {"extra_cuda_cflags": cuda_flags}),
+        ("rwkv7_fast_ops_fp16", [str(CUDA_DIR / "rwkv7_fast_ops_fp16.cpp"), str(CUDA_DIR / "rwkv7_fast_ops_fp16.cu")], {"extra_cuda_cflags": cuda_flags}),
+        ("rwkv7_int8_ops", [str(CUDA_DIR / "rwkv7_int8_ops.cpp"), str(CUDA_DIR / "rwkv7_int8_ops.cu")], {"extra_cuda_cflags": cuda_flags}),
+    ]
     if wkv_mode == "fp16":
-        load(name="rwkv7_wkv_fp16_v2", sources=[str(CUDA_DIR / "rwkv7_wkv_fp16_v2.cpp"), str(CUDA_DIR / "rwkv7_wkv_fp16_v2.cu")], is_python_module=False, verbose=False, extra_cflags=["-O3"], extra_cuda_cflags=["-O3", "-res-usage", "--extra-device-vectorization", "-Xptxas", "-O3"])
+        exts.append(("rwkv7_wkv_fp16_v2", [str(CUDA_DIR / "rwkv7_wkv_fp16_v2.cpp"), str(CUDA_DIR / "rwkv7_wkv_fp16_v2.cu")], {"extra_cuda_cflags": ["-O3", "-res-usage", "--extra-device-vectorization", "-Xptxas", "-O3"]}))
     elif wkv_mode == "fp32io16":
-        load(name="rwkv7_wkv_fp32_v2", sources=[str(CUDA_DIR / "rwkv7_wkv_fp32_v2.cpp"), str(CUDA_DIR / "rwkv7_wkv_fp32_v2.cu")], is_python_module=False, verbose=False, extra_cflags=["-O3", "-D_IO_FP16_"], extra_cuda_cflags=["-O3", "--use_fast_math", "-Xptxas", "-O3", "-D_IO_FP16_"])
+        exts.append(("rwkv7_wkv_fp32_v2", [str(CUDA_DIR / "rwkv7_wkv_fp32_v2.cpp"), str(CUDA_DIR / "rwkv7_wkv_fp32_v2.cu")], {"extra_cflags": ["-O3", "-D_IO_FP16_"], "extra_cuda_cflags": ["-O3", "--use_fast_math", "-Xptxas", "-O3", "-D_IO_FP16_"]}))
     else:
         raise ValueError(f"unknown wkv_mode: {wkv_mode}")
+    for name, sources, extra in exts:
+        te = time.perf_counter()
+        load(name=name, sources=sources, is_python_module=False, verbose=False, extra_cflags=extra.get("extra_cflags", ["-O3"]), **{k: v for k, v in extra.items() if k != "extra_cflags"})
+        log(f"  {name}: {time.perf_counter() - te:.3f}s")
     log(f"CUDA extensions loaded in {time.perf_counter() - t0:.3f}s")
 
 class RWKV7:
@@ -263,6 +270,16 @@ class RWKV7:
             value = z[key].squeeze()
             dev = key_device(key)
             is_lowrank = is_lowrank_weight(key)
+
+            # 离线量化的 int8 权重：保持 int8，只移到 GPU
+            if value.dtype == torch.int8:
+                z[key] = value.to(device=dev).contiguous()
+                continue
+            # scale 张量：1D [N] fp16，移到 GPU，不转置
+            if key.endswith("_scale"):
+                z[key] = value.to(device=dev, dtype=DTYPE).contiguous()
+                continue
+
             if ".ffn.key.weight" in key and CMIX_SPARSE == "auto":
                 z[key + ".fc"] = value.to(device=dev, dtype=DTYPE).contiguous()
             if (
@@ -286,6 +303,12 @@ class RWKV7:
                     z[key + ".t"] = value.t().contiguous()
             else:
                 z[key] = value
+        # INT8 模型不走 rkv 融合路径（rkv 需要 fp16 权重）
+        has_int8_att = z["blocks.0.att.receptance.weight"].dtype == torch.int8
+        if not has_int8_att and RKV_MODE != "off" and not use_orig_linear("att_c2c"):
+            for layer in range(L):
+                p = f"blocks.{layer}.att."
+                z[p+"rkv.weight"] = torch.stack((z[p+"receptance.weight"], z[p+"key.weight"], z[p+"value.weight"])).contiguous()
         emb_dev = first_device()
         ln0_w_bf16 = ln0_w_src.to(device=emb_dev).contiguous()
         ln0_b_bf16 = ln0_b_src.to(device=emb_dev).contiguous()
@@ -302,13 +325,14 @@ class RWKV7:
                     chunk = torch.ops.rwkv7_v3a_ops.emb_ln0_bf16_to_f16(chunk, ln0_w_bf16, ln0_b_bf16)
                     emb[start:end].copy_(chunk)
             z["emb.weight"] = emb
-        if RKV_MODE != "off" and not use_orig_linear("att_c2c"):
-            for layer in range(L):
-                p = f"blocks.{layer}.att."
-                z[p+"rkv.weight"] = torch.stack((z[p+"receptance.weight"], z[p+"key.weight"], z[p+"value.weight"])).contiguous()
         self.z = z
         self.emb_cpu = EMB_DEVICE == "cpu"
         self.emb_cache: dict[tuple[int, int], tuple[torch.Tensor, torch.Tensor]] = {}
+        # INT8 权重→scale 的快速查找表
+        self.int8_scales: dict[int, torch.Tensor] = {}
+        for key, val in z.items():
+            if key.endswith("_scale") and z.get(key[:-6], torch.tensor(0)).dtype == torch.int8:
+                self.int8_scales[id(z[key[:-6]])] = val
         sync_all()
         log(f"model ready in {time.perf_counter() - t0:.3f}s L={L} C={C} H={H} N={N} V={V}")
         log(cuda_mem())
@@ -605,18 +629,78 @@ class RWKV7:
         return self.linear(k, z[p+"value.weight"])
 
     def linear(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        """线性层。INT8 权重 CUDA dequant 后走原版 fp16 路径。"""
+        if weight.dtype == torch.int8:
+            scale = self.int8_scales.get(id(weight))
+            if scale is not None:
+                # CUDA dequant int8 [N,K] → fp16 [K,N]
+                weight = torch.ops.rwkv7_int8_ops.dequant_int8_to_f16(weight, scale, True)
         if x.numel() == x.size(-1) and weight.size(1) % 64 == 0:
             return torch.ops.rwkv7_v3a_ops.linear_f16_m1_splitk(x.contiguous(), weight)
         return torch.ops.rwkv7_v3a_ops.linear_f16(x.contiguous(), weight)
 
     def linear_head(self, x: torch.Tensor) -> torch.Tensor:
         z = self.z
-        if not use_orig_linear("head"):
-            return self.linear(x, z["head.weight"])
+        weight = z["head.weight"]
+        # int8 head 走 linear_orig_layout（int8 dispatch 在那里）
+        if not use_orig_linear("head") and weight.dtype != torch.int8:
+            return self.linear(x, weight)
         rows = x.numel() // C
-        return self.linear_orig_layout(x, z["head.weight"], PathConfig(rows, False, CMIX_DENSE), "head")
+        return self.linear_orig_layout(x, weight, PathConfig(rows, False, CMIX_DENSE), "head")
+
+    def _int8_rows_tile(self, rows: int) -> tuple[int, int]:
+        """选择 INT8 GEMM kernel 的 RowTile/OutTile 参数
+        4-wide K 循环下 OutTile=4 寄存器压力大：
+          M=4 OT=4: 78 regs, M=8 OT=4: 106 regs, M=8 OT=2: 87 regs
+        微基准+端到端验证：
+          M=4: OT=4 快（16.86 vs 18.74 ms）
+          M=8: OT=2 快（24.66 vs 27.40 ms）
+        """
+        if rows <= 4:
+            return 4, 4
+        if rows <= 8:
+            return 8, 2
+        if rows <= 16:
+            return 16, 2
+        return 16, 4
 
     def linear_orig_layout(self, x: torch.Tensor, weight: torch.Tensor, path: PathConfig, group: str) -> torch.Tensor:
+        # INT8 orig 权重：rows 1/2 走 int8 exact kernel（1:1 对应原版参数选择）
+        # rows>2 dequant 到 fp16，走原版 fp16 dispatch
+        if weight.dtype == torch.int8:
+            scale = self.int8_scales[id(weight)]
+            xc = x.contiguous()
+            if path.rows == 1:
+                if group == "ffn_key":
+                    use4 = True if C == 2560 else (C <= 1024)
+                else:
+                    use4 = (group != "att_c2c" or C < 2048)
+                return torch.ops.rwkv7_int8_ops.linear_int8_orig_rows_exact_f16(xc, weight, scale, 128, 2, use4)
+            if path.rows == 2:
+                if group == "att_c2c":
+                    return torch.ops.rwkv7_int8_ops.linear_int8_orig_rows_exact_f16(xc, weight, scale, 64, 2, True)
+                if group == "ffn_key":
+                    if C == 2560:
+                        return torch.ops.rwkv7_int8_ops.linear_int8_orig_rows_exact_f16(xc, weight, scale, 128, 2, False)
+                    if C < 4096:
+                        return torch.ops.rwkv7_int8_ops.linear_int8_orig_rows_exact_f16(xc, weight, scale, 64, 2, True)
+                    return torch.ops.rwkv7_int8_ops.linear_int8_orig_rows_exact_f16(xc, weight, scale, 128, 2, False)
+                if group == "head" and C == 2560:
+                    return torch.ops.rwkv7_int8_ops.linear_int8_orig_rows_exact_f16(xc, weight, scale, 128, 2, False)
+                return torch.ops.rwkv7_int8_ops.linear_int8_orig_rows_exact_f16(xc, weight, scale, 64, 2, True)
+            # rows > 2: 混合策略
+            #   att_c2c/head rows <= 16: INT8 direct kernel（微基准 M=16 时比 dequant+cuBLAS 快）
+            #   ffn_key rows <= 12: INT8 direct kernel（ffn_key M=16 时 cuBLAS 更快）
+            #   超过阈值: dequant → cuBLAS
+            int8_thresh = 16 if group in ("att_c2c", "head") else 12
+            if path.rows <= int8_thresh:
+                rt, ot = self._int8_rows_tile(path.rows)
+                return torch.ops.rwkv7_int8_ops.linear_int8_orig_rows_f16(xc, weight, scale, rt, ot)
+            if use_orig_linear(group):
+                weight = torch.ops.rwkv7_int8_ops.dequant_int8_to_f16(weight, scale, False)  # [N,K] fp16 orig
+            else:
+                weight = torch.ops.rwkv7_int8_ops.dequant_int8_to_f16(weight, scale, True)   # [K,N] fp16 non-orig
+        # 原版 fp16 路径完全不动
         if not use_orig_linear(group):
             return self.linear(x, weight)
         if path.rows == 1:

--- a/faster3a_2605/test_v5_kernel.py
+++ b/faster3a_2605/test_v5_kernel.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""v5 INT8 kernel 测试 — 边界条件 + 正确性 + 速度"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import torch
+from torch.utils.cpp_extension import load
+
+THIS_DIR = Path(__file__).resolve().parent
+CUDA_DIR = THIS_DIR / "cuda"
+
+def log(msg):
+    print(f"[v5test] {msg}", flush=True)
+
+def load_int8_ext():
+    """编译加载 int8 ops"""
+    cuda_flags = ["-O3", "--use_fast_math", "--extra-device-vectorization", "-Xptxas", "-O3"]
+    load(name="rwkv7_int8_ops",
+         sources=[str(CUDA_DIR / "rwkv7_int8_ops.cpp"), str(CUDA_DIR / "rwkv7_int8_ops.cu")],
+         is_python_module=False, verbose=True, extra_cflags=["-O3"], extra_cuda_cflags=cuda_flags)
+    log("int8_ops compiled OK")
+
+def load_v3a_ext():
+    """编译加载原版 v3a ops"""
+    cuda_flags = ["-O3", "--use_fast_math", "--extra-device-vectorization", "-Xptxas", "-O3"]
+    load(name="rwkv7_v3a_ops",
+         sources=[str(CUDA_DIR / "rwkv7_v3a_ops.cpp"), str(CUDA_DIR / "rwkv7_v3a_ops.cu")],
+         is_python_module=False, verbose=False, extra_cflags=["-O3"], extra_cuda_cflags=cuda_flags)
+    log("v3a_ops compiled OK")
+
+def quantize_per_channel_symmetric(w_fp16):
+    """per-channel symmetric quantization, w [N,K] -> int8 [N,K] + scale [N]"""
+    wf = w_fp16.float()
+    max_abs = wf.abs().max(dim=1, keepdim=True).values
+    max_abs = torch.clamp(max_abs, min=1e-10)
+    scale = (max_abs / 127.0).squeeze(1).to(torch.float16)
+    w_int8 = (wf / max_abs * 127.0).round().clamp(-128, 127).to(torch.int8)
+    return w_int8, scale
+
+def cos_sim(a, b):
+    """cosine similarity for 1D tensors"""
+    return torch.nn.functional.cosine_similarity(a.float().flatten().unsqueeze(0),
+                                                  b.float().flatten().unsqueeze(0)).item()
+
+def max_rel_err(a, b):
+    """max relative error"""
+    denom = torch.max(a.abs().float(), b.abs().float())
+    denom = torch.clamp(denom, min=1e-8)
+    return (torch.abs(a.float() - b.float()) / denom).max().item()
+
+# ═══════════════════════════════════════════════════════════════
+# Test 1: M=1 kernel correctness — various sizes
+# ═══════════════════════════════════════════════════════════════
+
+def test_m1_correctness():
+    log("=" * 60)
+    log("Test 1: M=1 kernel correctness")
+    log("=" * 60)
+
+    torch.manual_seed(42)
+    test_cases = [
+        # (N, K, use4, desc)
+        (4096, 4096, False, "att_c2c 4096x4096 use4=False"),
+        (4096, 4096, True,  "head 4096x4096 use4=True"),
+        (16384, 4096, True, "ffn_key 16384x4096 use4=True"),
+        (16384, 4096, False, "ffn_key 16384x4096 use4=False"),
+        (65536, 4096, True, "head 65536x4096 use4=True"),
+        # boundary: small sizes
+        (2, 4, True, "min exact4 N=2 K=4"),
+        (2, 2, False, "min exact N=2 K=2"),
+        (4, 8, True, "small N=4 K=8 use4=True"),
+        (4, 8, False, "small N=4 K=8 use4=False"),
+        # boundary: K not divisible by 4 but by 2
+        (128, 6, False, "K=6 use4=False (not div by 4)"),
+        (128, 10, False, "K=10 use4=False (not div by 4)"),
+        # boundary: large K
+        (128, 8192, True, "K=8192 use4=True"),
+        (128, 8192, False, "K=8192 use4=False"),
+    ]
+
+    all_pass = True
+    for N, K, use4, desc in test_cases:
+        # 生成随机数据
+        w_fp16 = (torch.randn(N, K, device="cuda") * 0.02).to(torch.float16)
+        x_fp16 = torch.randn(1, K, device="cuda", dtype=torch.float16) * 0.5
+
+        # 量化
+        w_int8, scale = quantize_per_channel_symmetric(w_fp16)
+
+        # int8 kernel
+        try:
+            y_int8 = torch.ops.rwkv7_int8_ops.linear_int8_orig_rows_exact_f16(
+                x_fp16.contiguous(), w_int8.contiguous(), scale.contiguous(),
+                128, 2, use4)
+        except Exception as e:
+            log(f"  FAIL [{desc}]: kernel error: {e}")
+            all_pass = False
+            continue
+
+        # fp16 reference (用原版 v3a kernel)
+        try:
+            y_fp16 = torch.ops.rwkv7_v3a_ops.linear_orig_rows_exact_f16(
+                x_fp16.contiguous(), w_fp16.contiguous(), 128, 2, use4)
+        except Exception as e:
+            # 如果原版 kernel 不支持这个尺寸，用 PyTorch matmul 做 reference
+            y_fp16 = (x_fp16 @ w_fp16.t()).to(torch.float16)
+
+        # 比较
+        cs = cos_sim(y_int8, y_fp16)
+        mre = max_rel_err(y_int8, y_fp16)
+        status = "PASS" if cs >= 0.966 else "FAIL"
+        if status == "FAIL":
+            all_pass = False
+        log(f"  {status} [{desc}]: CosSim={cs:.6f} MaxRelErr={mre:.6f}")
+
+    return all_pass
+
+# ═══════════════════════════════════════════════════════════════
+# Test 2: M=2 kernel correctness
+# ═══════════════════════════════════════════════════════════════
+
+def test_m2_correctness():
+    log("=" * 60)
+    log("Test 2: M=2 kernel correctness")
+    log("=" * 60)
+
+    torch.manual_seed(42)
+    test_cases = [
+        (4096, 4096, True, "att_c2c M=2 use4=True"),
+        (4096, 4096, False, "att_c2c M=2 use4=False"),
+        (16384, 4096, True, "ffn_key M=2 use4=True"),
+        (128, 8, True, "small M=2 use4=True"),
+        (128, 8, False, "small M=2 use4=False"),
+    ]
+
+    all_pass = True
+    for N, K, use4, desc in test_cases:
+        w_fp16 = (torch.randn(N, K, device="cuda") * 0.02).to(torch.float16)
+        x_fp16 = torch.randn(2, K, device="cuda", dtype=torch.float16) * 0.5
+        w_int8, scale = quantize_per_channel_symmetric(w_fp16)
+
+        try:
+            # M=2 dispatch 参数选择（和 Python dispatch 一致）
+            if use4:
+                threads = 64  # att_c2c M=2 use4=True → <64, 2, True>
+            else:
+                threads = 128  # M=2 use4=False → <128, 2, False>
+            y_int8 = torch.ops.rwkv7_int8_ops.linear_int8_orig_rows_exact_f16(
+                x_fp16.contiguous(), w_int8.contiguous(), scale.contiguous(),
+                threads, 2, use4)
+        except Exception as e:
+            log(f"  FAIL [{desc}]: kernel error: {e}")
+            all_pass = False
+            continue
+
+        # PyTorch reference
+        y_ref = (x_fp16 @ w_fp16.t()).to(torch.float16)
+
+        cs = cos_sim(y_int8, y_ref)
+        mre = max_rel_err(y_int8, y_ref)
+        status = "PASS" if cs >= 0.966 else "FAIL"
+        if status == "FAIL":
+            all_pass = False
+        log(f"  {status} [{desc}]: CosSim={cs:.6f} MaxRelErr={mre:.6f}")
+
+    return all_pass
+
+# ═══════════════════════════════════════════════════════════════
+# Test 3: FP16 regression — original path still works
+# ═══════════════════════════════════════════════════════════════
+
+def test_fp16_regression():
+    log("=" * 60)
+    log("Test 3: FP16 regression (original path)")
+    log("=" * 60)
+
+    torch.manual_seed(42)
+    K, N = 4096, 4096
+    w_fp16 = (torch.randn(N, K, device="cuda") * 0.02).to(torch.float16)
+    x_fp16 = torch.randn(1, K, device="cuda", dtype=torch.float16) * 0.5
+
+    # 原版 kernel
+    try:
+        y_v3a = torch.ops.rwkv7_v3a_ops.linear_orig_rows_exact_f16(
+            x_fp16.contiguous(), w_fp16.contiguous(), 128, 2, True)
+        log(f"  PASS: v3a linear_orig_rows_exact_f16 works, output shape={y_v3a.shape}")
+        return True
+    except Exception as e:
+        log(f"  FAIL: v3a kernel error: {e}")
+        return False
+
+# ═══════════════════════════════════════════════════════════════
+# Test 4: M>1 dequant fallback
+# ═══════════════════════════════════════════════════════════════
+
+def test_m_gt2_dequant():
+    log("=" * 60)
+    log("Test 4: M>2 dequant fallback (linear function)")
+    log("=" * 60)
+
+    torch.manual_seed(42)
+    N, K = 4096, 4096
+    w_fp16 = (torch.randn(N, K, device="cuda") * 0.02).to(torch.float16)
+    w_int8, scale = quantize_per_channel_symmetric(w_fp16)
+
+    all_pass = True
+    for M in [3, 4, 8, 32]:
+        x = torch.randn(M, K, device="cuda", dtype=torch.float16) * 0.5
+        # 模拟 linear() 中的 dequant fallback
+        w_dequant = (w_int8.float() * scale.unsqueeze(1).float()).to(torch.float16)
+        w_for_linear = w_dequant.t().contiguous()  # [K, N]
+        y = torch.ops.rwkv7_v3a_ops.linear_f16(x.contiguous(), w_for_linear)
+
+        # reference
+        y_ref = (x @ w_fp16.t()).to(torch.float16)
+        cs = cos_sim(y, y_ref)
+        status = "PASS" if cs >= 0.966 else "FAIL"
+        if status == "FAIL":
+            all_pass = False
+        log(f"  {status} [M={M}]: CosSim={cs:.6f}")
+
+    return all_pass
+
+# ═══════════════════════════════════════════════════════════════
+# Test 5: Speed benchmark
+# ═══════════════════════════════════════════════════════════════
+
+def test_speed():
+    log("=" * 60)
+    log("Test 5: Speed benchmark")
+    log("=" * 60)
+
+    torch.manual_seed(42)
+    shapes = [
+        (4096, 4096, False, "att_c2c"),
+        (4096, 4096, True, "att_c2c use4"),
+        (16384, 4096, False, "ffn_key"),
+        (65536, 4096, True, "head"),
+    ]
+
+    for N, K, use4, desc in shapes:
+        w_fp16 = (torch.randn(N, K, device="cuda") * 0.02).to(torch.float16)
+        x = torch.randn(1, K, device="cuda", dtype=torch.float16) * 0.5
+        w_int8, scale = quantize_per_channel_symmetric(w_fp16)
+
+        # warmup
+        for _ in range(10):
+            torch.ops.rwkv7_int8_ops.linear_int8_orig_rows_exact_f16(
+                x, w_int8, scale, 128, 2, use4)
+        torch.cuda.synchronize()
+
+        # int8 timing
+        iters = 100
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            torch.ops.rwkv7_int8_ops.linear_int8_orig_rows_exact_f16(
+                x, w_int8, scale, 128, 2, use4)
+        torch.cuda.synchronize()
+        t_int8 = (time.perf_counter() - t0) / iters * 1000
+
+        # fp16 timing
+        for _ in range(10):
+            torch.ops.rwkv7_v3a_ops.linear_orig_rows_exact_f16(
+                x, w_fp16, 128, 2, use4)
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            torch.ops.rwkv7_v3a_ops.linear_orig_rows_exact_f16(
+                x, w_fp16, 128, 2, use4)
+        torch.cuda.synchronize()
+        t_fp16 = (time.perf_counter() - t0) / iters * 1000
+
+        log(f"  {desc}: int8={t_int8:.3f}ms fp16={t_fp16:.3f}ms ratio={t_int8/t_fp16:.2f}x")
+
+# ═══════════════════════════════════════════════════════════════
+# Test 6: Zero weight edge case
+# ═══════════════════════════════════════════════════════════════
+
+def test_zero_weight():
+    log("=" * 60)
+    log("Test 6: Zero weight edge case")
+    log("=" * 60)
+
+    N, K = 128, 256
+    w_fp16 = torch.zeros(N, K, device="cuda", dtype=torch.float16)
+    x = torch.randn(1, K, device="cuda", dtype=torch.float16) * 0.5
+    w_int8, scale = quantize_per_channel_symmetric(w_fp16)
+
+    y = torch.ops.rwkv7_int8_ops.linear_int8_orig_rows_exact_f16(
+        x, w_int8, scale, 128, 2, True)
+
+    # output should be all zeros
+    max_val = y.abs().max().item()
+    log(f"  max output abs value: {max_val:.10f} (should be ~0)")
+    return max_val < 1e-5
+
+# ═══════════════════════════════════════════════════════════════
+# Main
+# ═══════════════════════════════════════════════════════════════
+
+if __name__ == "__main__":
+    log("Starting v5 INT8 kernel tests...")
+    log(f"PyTorch {torch.__version__}, CUDA {torch.version.cuda}")
+
+    # Clear cache first
+    cache_dir = os.path.expanduser("~/.cache/torch_extensions")
+    if os.path.exists(cache_dir):
+        import shutil
+        shutil.rmtree(cache_dir)
+        log(f"Cleared torch extensions cache at {cache_dir}")
+
+    load_int8_ext()
+    load_v3a_ext()
+
+    results = []
+    results.append(("M=1 correctness", test_m1_correctness()))
+    results.append(("M=2 correctness", test_m2_correctness()))
+    results.append(("FP16 regression", test_fp16_regression()))
+    results.append(("M>2 dequant", test_m_gt2_dequant()))
+    results.append(("Zero weight", test_zero_weight()))
+
+    # Speed benchmark (not a pass/fail test)
+    test_speed()
+
+    log("=" * 60)
+    log("Summary")
+    log("=" * 60)
+    all_pass = True
+    for name, passed in results:
+        status = "PASS" if passed else "FAIL"
+        if not passed:
+            all_pass = False
+        log(f"  {status}: {name}")
+
+    if all_pass:
+        log("ALL TESTS PASSED")
+    else:
+        log("SOME TESTS FAILED")
+        sys.exit(1)


### PR DESCRIPTION
# INT8 量化推理支持

## 概述

为 RWKV-7 v3a 推理引擎添加 INT8 权重量化支持，在保持精度的前提下将显存占用减半，并通过 4-wide K 循环、向量化 dequant、按权重组区分阈值等优化，在大 B×1 场景下显著提升吞吐。

## 改动

### 新增文件

- `cuda/rwkv7_int8_ops.cu` / `.cpp` — INT8 量化推理 CUDA kernel：
  - `linear_int8_orig_rows_exact_f16`：M=1/2 GEMV，int8 权重即时 dequant + fmaf
  - `linear_int8_orig_rows_f16`：M≥3 GEMM，4-wide K 循环模板（K%4==0 时自动启用）
  - `dequant_int8_to_f16`：int8→fp16 反量化，非转置路径 8-wide 向量化
- `quantize_int8.py` — 离线 INT8 量化工具（per-channel symmetric，仅量化 att/ffn_key/head 大矩阵）
- `test_v5_kernel.py` — kernel 正确性与性能测试

### 修改文件

- `rwkv7_fast_v3a.py`：
  - `load_extensions` 加载 int8_ops 扩展并输出各 extension 编译耗时
  - 权重加载时 int8/scale 张量直接移到 GPU 不做 fp16 转换
  - `linear` / `linear_orig_layout` 增加 int8 路径分发
  - `_int8_rows_tile`：按 M 选择 RowTile/OutTile（M≤4→(4,4)，M>4→(8,2) 降寄存器压力）
  - INT8 阈值按权重组区分（att_c2c/head ≤16，ffn_key ≤12）

## 性能

测试环境：RTX 5070 Ti（12GB VRAM），RWKV-7 7.2B INT8 模型，WSL2 + CUDA 13.0

大 B×1 场景（多用户并行生成）：

| B | 优化前 tok/s | 优化后 tok/s | 提升 |
|---|---|---|---|
| 4 | 51 | 235 | 4.6x |
| 8 | 41 | 336 | 8.2x |
| 16 | 18 | 307 | 17x |
| 32 | 15 | 596 | 40x |
| 64 | 11 | 1013 | 92x |
| 128 | 4 | 979 | 245x |

（优化前为 FP16 模型走 CPU offload 的数据，INT8 方案将模型装入 VRAM 后性能提升数量级）

INT8 kernel 自身优化效果（vs 2-wide 基线）：

| 场景 | 提升 |
|---|---|
| 1x4 prefill | 快 36% |
| 1x8 prefill | 快 9% |
| B=64 生成 | 快 16% |
| B=128 生成 | 快 43% |

## 用法

```bash
# 1. 量化模型
python3 quantize_int8.py --model model.pth --out model-int8.pth --verify

# 2. 推理（自动识别 int8 权重）
python3 rwkv7_fast_v3a.py --model model-int8.pth
```

## 精度

per-channel symmetric INT8 量化，cos_sim > 0.999（vs FP16 参考）。仅量化 att.r/k/v/o、ffn.key、head 权重，ffn.value（sparse cmix）、低秩权重、embedding/LN 不量化。
